### PR TITLE
Add Convolution Encoder IP and fix FFT interrupt classification

### DIFF
--- a/configs/convolution_testing.yaml
+++ b/configs/convolution_testing.yaml
@@ -1,0 +1,22 @@
+# Convolution-Encoder-focused stream config: forces the Convolution Encoder into
+# the mix alongside other AXI4-Stream producers/consumers (FFT, AXI DMA) and a
+# MicroBlaze/UART subsystem for AXI + interrupt context. Used to validate the
+# convolution IP through Vivado.
+vivado_version: v2024_2
+
+axi_mm:
+  no_master: [external, jtag]
+
+axi_stream:
+  io_converters: random
+  internal_converters: random
+
+available_ip:
+  - class: ConvolutionEncoder
+  - class: Fft
+  - class: AxiDma
+  - class: Microblaze
+  - class: Uartlite
+
+min_ip: 4
+max_ip: 8

--- a/rand_soc/creator.py
+++ b/rand_soc/creator.py
@@ -45,6 +45,7 @@ def import_ip(version, versions):
         ("axis_combiner", ["AxisCombiner"]),
         ("axis_dwidth_converter", ["AxisDwidthConverter"]),
         ("cordic", ["Cordic"]),
+        ("convolution", ["ConvolutionEncoder"]),
     ]
     versions = versions[versions.index(version) :]
     for lib, ips in ips:

--- a/rand_soc/ip/ip_base.py
+++ b/rand_soc/ip/ip_base.py
@@ -13,7 +13,7 @@ import math
 
 from rand_soc.typedefs import ConverterReq, Direction, Protocol
 
-from ..utils import all_ones, randintwidth
+from ..utils import all_ones, randintwidth, randpuncture
 from ..ports import IpPort
 
 
@@ -222,6 +222,7 @@ class IPrandom(IP):
         self.config_vars = {}
         self.config_vars["all_ones"] = all_ones
         self.config_vars["randintwidth"] = randintwidth
+        self.config_vars["randpuncture"] = randpuncture
 
         with open(yaml_path, "r") as f:
             ip_data = yaml.safe_load(f)

--- a/rand_soc/ip/v2020_2/convolution.py
+++ b/rand_soc/ip/v2020_2/convolution.py
@@ -1,0 +1,14 @@
+"""Convolution Encoder IP"""
+
+from ..ip_base import IPrandom
+
+
+class ConvolutionEncoder(IPrandom):
+    """Convolution Encoder IP class"""
+
+    @property
+    def name(self):
+        return "conv_encoder"
+
+    def randomize(self):
+        self.load_data_from_yaml(__file__)

--- a/rand_soc/ip/v2020_2/convolution.yaml
+++ b/rand_soc/ip/v2020_2/convolution.yaml
@@ -1,0 +1,149 @@
+- id: "conv_encoder_0"
+  definition: "xilinx.com:ip:convolution:9.0"
+  configuration:
+
+  # Config names below are the CONFIG.* user-parameter names from PG026
+  # (Convolutional Encoder v9.0), Table 4-1 -- all lowercase.
+
+  ##### (1) Data Rates and Puncturing #####
+
+  # Whether the core punctures the rate-1/2 encoded data before output. Both
+  # modes are supported; the input_rate / output_rate ranges and the puncture
+  # codes below switch on this.
+  - name: punctured
+    values: [false, true]
+
+  # Dual-channel (two bits at a time) output. Vivado greys this out unless the
+  # core is punctured, so gate it on punctured.
+  - name: dual_output
+    enable: punctured
+    values: [false, true]
+    default: false
+
+  # Input rate n. Non-punctured cores are rate 1/m, so the input rate is fixed at
+  # 1 (the field is disabled in the GUI). When punctured it can range 2..12,
+  # giving a rate n/m core.
+  - name: input_rate
+    values_eval: "range(2, 13) if punctured else [1]"
+
+  # Output rate m. Non-punctured: 2..7 (rate 1/2 .. 1/7). Punctured: PG026
+  # requires n < m < 2n, i.e. m in [input_rate+1, 2*input_rate-1].
+  - name: output_rate
+    values_eval: "range(input_rate + 1, 2 * input_rate) if punctured else range(2, 8)"
+
+  # Puncture pattern codes. They must be generated jointly: each is input_rate
+  # bits long and the total number of 1-bits across both equals output_rate
+  # (PG026). randpuncture() returns the valid pair as zero-padded n-bit binary
+  # strings (puncture codes have no radix parameter, unlike the convolution
+  # codes). The pair is computed once in an internal var and split into the two
+  # fields. Only evaluated when punctured; otherwise both default to 0.
+  - name: _puncture_pattern
+    internal: true
+    enable: punctured
+    value_eval: "randpuncture(input_rate, output_rate)"
+    default: 0
+
+  - name: puncture_code0
+    enable: punctured
+    value_eval: "_puncture_pattern[0]"
+    default: 0
+
+  - name: puncture_code1
+    enable: punctured
+    value_eval: "_puncture_pattern[1]"
+    default: 0
+
+  ##### (2) Convolution #####
+
+  # Constraint length: length of the constraint register plus 1. PG026 allows
+  # 3..9 inclusive.
+  - name: constraint_length
+    values_eval: "range(3, 10)"
+
+  # Codes are entered in binary, octal or decimal -- the radix is only an input
+  # format and does not change the generated hardware. Decimal lets us feed a
+  # plain random integer (randintwidth) with no zero-padded string formatting.
+  - name: convolution_code_radix
+    value: Decimal
+
+  # Generator polynomials, one per convolution_codeN field (0..6). Each is a
+  # random value of constraint_length bits (decimal radix). The core uses only as
+  # many as the mode needs -- output_rate of them when non-punctured, two when
+  # punctured -- and ignores the rest; generating all seven at the correct width
+  # keeps every field valid regardless of which are active.
+  - name: convolution_code0
+    value_eval: "randintwidth(constraint_length)"
+  - name: convolution_code1
+    value_eval: "randintwidth(constraint_length)"
+  - name: convolution_code2
+    value_eval: "randintwidth(constraint_length)"
+  - name: convolution_code3
+    value_eval: "randintwidth(constraint_length)"
+  - name: convolution_code4
+    value_eval: "randintwidth(constraint_length)"
+  - name: convolution_code5
+    value_eval: "randintwidth(constraint_length)"
+  - name: convolution_code6
+    value_eval: "randintwidth(constraint_length)"
+
+  ##### (3) Optional Pins #####
+
+  # Output AXI-Stream TREADY handshake on M_AXIS_DATA.
+  - name: tready
+    values: [false, true]
+    default: true
+
+  # Clock-enable pin. Randomized per the design decision to expose it (unlike
+  # CORDIC, where it is held off).
+  - name: aclken
+    values: [false, true]
+
+  ports:
+
+  - name: aclk
+    protocol: clk
+    direction: I
+    width: 1
+    connections:
+    - conv_encoder_0/aclk
+
+  - name: aclken
+    protocol: control
+    direction: I
+    width: 1
+    enable: aclken
+    connections:
+    - conv_encoder_0/aclken
+
+  # Active-Low synchronous clear. Always present (not an optional pin).
+  - name: aresetn
+    protocol: reset_interconnect
+    direction: I
+    width: 1
+    connections:
+    - conv_encoder_0/aresetn
+
+  # S_AXIS_DATA is always one byte (8 bits) regardless of input_rate -- Vivado
+  # reports TDATA_NUM_BYTES=1 even for punctured rates 9-12 (confirmed by the
+  # width-check probe). Its TDATA carries a typed "data_in" field that Vivado
+  # type-checks, so a foreign stream -- e.g. another encoder's M_AXIS "data_out"
+  # field -- must never land on it directly even when the byte width matches
+  # (Vivado convolution:9.0-309 "field width mismatch"). converter_req: always
+  # forces a width converter that normalises the source into a plain single-field
+  # TDATA first, exactly as CORDIC does for its typed inputs.
+  - name: S_AXIS_DATA
+    protocol: "xilinx.com:interface:axis_rtl:1.0"
+    direction: Slave
+    width: 8
+    converter_req: always
+    connections:
+    - conv_encoder_0/S_AXIS_DATA
+
+  # M_AXIS_DATA output is always zero-padded to one byte (PG026, "Output Data
+  # Channel TDATA Structure"), so a flat 8 bits regardless of mode.
+  - name: M_AXIS_DATA
+    protocol: "xilinx.com:interface:axis_rtl:1.0"
+    direction: Master
+    width: 8
+    connections:
+    - conv_encoder_0/M_AXIS_DATA

--- a/rand_soc/ip/v2020_2/cordic.yaml
+++ b/rand_soc/ip/v2020_2/cordic.yaml
@@ -158,14 +158,14 @@
 
   ##### (6) Optional pins #####
 
-  # ACLKEN is held off. The aclken pin is a clock-enable (Vivado type 'ce'); when
-  # exposed it falls into the generic CONTROL random-connection pool, whose only
-  # driver is an event/interrupt-typed output (e.g. the FFT's event_frame_started),
-  # and Vivado rejects the intr->ce connection (BD 41-1308). There is no
-  # clock-enable network in these random designs to drive it compatibly, so it
-  # stays disabled until the framework grows one.
+  # The aclken pin is a clock-enable (Vivado type 'ce'). It falls into the
+  # generic CONTROL random-connection pool; previously the only driver there was
+  # the FFT's event_frame_started, which Vivado rejected as an intr->ce
+  # connection (BD 41-1308) -- so ACLKEN was held off. Now that event_frame_started
+  # is correctly classified as IRQ (see fft.yaml), the CONTROL pool supplies a
+  # plain wire driver compatible with a ce pin, so ACLKEN can be randomized.
   - name: ACLKEN
-    values: [false]
+    values: [false, true]
 
   - name: ARESETn
     values: [false, true]

--- a/rand_soc/ip/v2020_2/fft.yaml
+++ b/rand_soc/ip/v2020_2/fft.yaml
@@ -38,8 +38,14 @@
     connections:
     - fft_0/aclk
 
+  # Vivado types this pin as 'intr' (an interrupt), not a generic control wire.
+  # Classifying it as IRQ routes it through the interrupt path (Intc -> the
+  # MicroBlaze interrupt input, or a top-level irq export) instead of the generic
+  # CONTROL pool. In the CONTROL pool it was the only available driver, and
+  # Vivado rejects wiring an intr source onto a control/ce input such as a
+  # CORDIC/Convolution-Encoder aclken (BD 41-1308, incompatible intr->ce).
   - name: event_frame_started
-    protocol: control
+    protocol: irq
     direction: O
     width: 1
     connections:

--- a/rand_soc/utils.py
+++ b/rand_soc/utils.py
@@ -16,6 +16,28 @@ def all_ones(width):
     return 2**width - 1
 
 
+def randpuncture(input_rate, output_rate):
+    """Random valid puncture-code pair for the Convolution Encoder.
+
+    PG026 rule: each of the two codes is ``input_rate`` (n) bits long and the
+    combined number of 1-bits across both equals ``output_rate`` (m), with
+    n < m < 2n. We pick m of the 2n bit positions uniformly at random; positions
+    [0, n) form code0 and [n, 2n) form code1. The exact bit order is irrelevant
+    to validity (only length and total popcount matter), so any such pattern is
+    legal. Returns the two codes as zero-padded n-bit binary strings (puncture
+    codes have no radix parameter, so they are entered as bit strings).
+    """
+    positions = random.sample(range(2 * input_rate), output_rate)
+    code0 = code1 = 0
+    for p in positions:
+        if p < input_rate:
+            code0 |= 1 << p
+        else:
+            code1 |= 1 << (p - input_rate)
+    fmt = "0{}b".format(input_rate)
+    return format(code0, fmt), format(code1, fmt)
+
+
 def pull_from_list(lst, new_list, fcn):
     lst_copy = []
     for item in lst:


### PR DESCRIPTION
## Summary
Adds the **Convolution Encoder** AXI-Stream IP (`xilinx.com:ip:convolution:9.0`) and fixes a framework-wide signal-classification bug surfaced while validating it.

### Convolution Encoder
- New `ConvolutionEncoder` IP with config options in PG026 order: punctured/non-punctured modes, input/output rates (with the `n<m<2n` puncture-rate rule), constraint length 3–9, random convolution codes (decimal radix), `tready`/`aclken` optional pins.
- Joint puncture-code generation via a new `randpuncture()` helper — each code `input_rate` bits, combined popcount `output_rate` (per PG026).
- `converter_req: always` on the typed `S_AXIS_DATA` input (flat 8-bit), mirroring CORDIC, so foreign streams are normalised through a width converter (avoids the `convolution:9.0-309` field-width check).

### FFT interrupt fix (framework-wide)
- `fft.yaml`: `event_frame_started` reclassified from `control` to **`irq`**. Vivado types this pin as `intr`, so in the generic CONTROL pool it was the only driver and Vivado rejected it onto `ce` inputs like `aclken` (`BD 41-1308`, `intr->ce`). As IRQ it now routes through the interrupt controller (or a top-level export).
- `cordic.yaml`: **re-enabled `ACLKEN`** (previously force-disabled for this exact reason), now that the control pool no longer carries the FFT interrupt.

## Validation
- **100/100** designs pass block-design validation in Vivado.
- **179/200** pass full synthesis. The 21 failures are pre-existing and unrelated to this work: FFT BRAM overutilization (large `channels × transform_length`), top-level IO overutilization, and slow-design synth timeouts — all confirmed independent of the convolution IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)