### PR TITLE
docs: add complete Supported IP listing to docs/ip.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,38 +52,18 @@ reference live in the documentation below.
   accepts (IP selection, Vivado version, AXI no-master strategy, AXIS converters).
 - [AXI4-Stream Connection](docs/axi_stream.md) — how RandSoC wires up AXI-Stream
   IP, including the source/sink assignment algorithm and width converters.
-- [Adding and Defining IP](docs/ip.md) — the IP YAML schema and how to add a new
-  IP block.
+- [Adding and Defining IP](docs/ip.md) — the IP YAML schema, how to add a new IP
+  block, and the **complete [Supported IP](docs/ip.md#supported-ip) list**
+  (randomized IP plus the IP added as needed).
 
 ## Supported IP
 
-### Randomized IP
-| Python Class | Description | Supported Configurations |
-|---------|-------------|--------------------------|
-|`Accumulator` | Xilinx *Accumulator* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/accumulator.html>) | Full configuration space |
-|`AxiCan` | Xilinx *AXI CAN* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_can.html>) | Full configuration space, but untested as a separate license is required. |
-|`AxiCdma` | Xilinx *AXI AXI Central DMA Controller* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_central_dma.html>) | Full configuration space |
-|`AxiDma` | Xilinx *AXI Direct Memory Access* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_dma.html>) | Full configuration space (SG/direct/Micro/multichannel, MM2S+S2MM, control/status streams) |
-|`AxiEthernetLite` | Xilinx *AXI Ethernet Lite* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_ethernetlite.html>) | Full configuration space |
-|`AxiHwicap` | Xilinx *AXI Hardware ICAP* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_hwicap.html>) | Full configuration space |
-|`AxiIic` | Xilinx *AXI IIC Bus Interface* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_iic.html>) | Full configuration space |
-|`AxiQuadSpi` | Xilinx *AXI Quad SPI* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_quadspi.html>) | Full configuration space |
-|`AxiTimer` | Xilinx *AXI Timer/Counter* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_timer.html>) | Full configuration space |
-|`AxiUsb2Device` | Xilinx *AXI USB 2.0 Device Controller* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_usb2_device.html>) | Full configuration space, but untested as a separate license is required. |
-|`Dft` | Xilinx *Discrete Fourier Transform (DFT)* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/dft.html>) | Full configuration space |
-|`Emc` | Xilinx *AXI External Memory Controller* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_emc.html>) | Only number of banks. Other options not yet enumerated. |
-|`Gpio` | Xilinx *AXI General Purpose IO* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_gpio.html>) | Full configuration space |
-|`Microblaze` | Xilinx *AMD MicroBlaze™ Processor* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/microblaze.html>) | All configurations with local memory bus (No AXI DDR support) |
-|`Uartlite` | Xilinx *AXI UART Lite* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_uartlite.html>) | Full configuration space |
-|`XadcWiz` | Xilinx *XADC Wizard* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/xadc-wizard.html>) | Full configuration space |
-
-### IP Added as Needed
-| Python Class | Description |
-|---------|-------------|
-|`AxiSmartconnect` | Xilinx *AXI SmartConnect* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/smartconnect.html>) |
-|`AxiInterconnect` | Xilinx *AXI Interconnect* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi-interconnect.html>) |
-|`ClkGen` | Xilinx *Clocking Wizard* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/clocking_wizard.html>) |
-|`Intc` | Xilinx *AXI Interrupt Controller* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_intc.html>) |
+RandSoC supports a range of randomly-configured Xilinx IP (GPIO, UART, FFT,
+CORDIC, Convolution Encoder, MicroBlaze, the AXI DMA family, …) plus the
+infrastructure IP added as a design requires it (interconnect, clocking,
+interrupt controller, and the AXI-Stream helpers). The full, canonical tables —
+with per-IP descriptions, links, and supported-configuration notes — live in
+[Adding and Defining IP → Supported IP](docs/ip.md#supported-ip).
 
 ## Adding new IP
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,10 +12,10 @@ This is the documentation index. See also:
 - **[Configuration File Reference](config.md)** — every key the config YAML accepts.
 - **[AXI4-Stream Connection](axi_stream.md)** — how stream IP are wired (the
   source/sink assignment algorithm, broadcasters, combiners, width converters).
-- **[Adding and Defining IP](ip.md)** — the IP YAML schema and how to add a new
-  IP block.
-- The repository [`README.md`](../README.md) — install/dependencies and the full
-  supported-IP table.
+- **[Adding and Defining IP](ip.md)** — the IP YAML schema, how to add a new IP
+  block, and the complete [Supported IP](ip.md#supported-ip) list.
+- The repository [`README.md`](../README.md) — install/dependencies and a project
+  overview.
 
 ## Running the tool
 
@@ -112,4 +112,4 @@ falling back to older versions when a given version lacks that module. This lets
 a version-specific variant override the base while unchanged IP fall through to a
 single shared copy.
 
-To add new IP, see the "IP Configurations" section of the [README](../README.md).
+To add new IP, see [Adding and Defining IP](ip.md).

--- a/docs/ip.md
+++ b/docs/ip.md
@@ -1,9 +1,62 @@
 # Adding and Defining IP
 
-This page describes how IP is defined in RandSoC and how to add a new IP block.
-For the list of IP that already ships, see the "Supported IP" section of the
-[README](../README.md). For how IP is loaded per Vivado version, see the IP and
-version-system section of the [documentation index](index.md).
+This page describes the IP RandSoC supports and how to add a new IP block. The
+[Supported IP](#supported-ip) section below is the complete, canonical list. For
+how IP is loaded per Vivado version, see the IP and version-system section of the
+[documentation index](index.md).
+
+## Supported IP
+
+The registry that backs these tables is `import_ip()` in
+[`rand_soc/creator.py`](../rand_soc/creator.py); keep them in sync when adding or
+removing an IP.
+
+### Randomized IP
+
+These are the IP that can be drawn and randomly configured from a config's
+`available_ip` list.
+
+| Python Class | Description | Supported Configurations |
+|---------|-------------|--------------------------|
+|`Accumulator` | Xilinx *Accumulator* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/accumulator.html>) | Full configuration space |
+|`AxiCan` | Xilinx *AXI CAN* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_can.html>) | Full configuration space, but untested as a separate license is required. |
+|`AxiCdma` | Xilinx *AXI Central DMA Controller* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_central_dma.html>) | Full configuration space |
+|`AxiDma` | Xilinx *AXI Direct Memory Access* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_dma.html>) | Full configuration space (SG/direct/Micro/multichannel, MM2S+S2MM, control/status streams) |
+|`AxiEthernetLite` | Xilinx *AXI Ethernet Lite* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_ethernetlite.html>) | Full configuration space |
+|`AxiHwicap` | Xilinx *AXI Hardware ICAP* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_hwicap.html>) | Full configuration space |
+|`AxiIic` | Xilinx *AXI IIC Bus Interface* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_iic.html>) | Full configuration space |
+|`AxiQuadSpi` | Xilinx *AXI Quad SPI* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_quadspi.html>) | Full configuration space |
+|`AxiTimer` | Xilinx *AXI Timer/Counter* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_timer.html>) | Full configuration space |
+|`AxiUsb2Device` | Xilinx *AXI USB 2.0 Device Controller* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_usb2_device.html>) | Full configuration space, but untested as a separate license is required. |
+|`ConvolutionEncoder` | Xilinx *Convolution Encoder* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/convolution.html>) | Constraint length 3–9 with up to seven code vectors, optional puncturing (dual output, input/output rates, random puncture patterns), and optional TREADY/ACLKEN. |
+|`Cordic` | Xilinx *CORDIC* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/cordic.html>) | All functions (Rotate, Translate, Sin/Cos, Sinh/Cosh, Arc Tan, Arc Tanh, Square Root), word-serial/parallel architecture, pipelining modes, 8–48-bit input/output, rounding/scaling modes, optional coarse rotation and TLAST/TUSER. |
+|`Dft` | Xilinx *Discrete Fourier Transform (DFT)* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/dft.html>) | Full configuration space |
+|`Emc` | Xilinx *AXI External Memory Controller* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_emc.html>) | Only number of banks. Other options not yet enumerated. |
+|`Fft` | Xilinx *Fast Fourier Transform (FFT)* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/fast-fourier-transform.html>) | 1–12 channels, transform length 8–65536 (log2 3–16), the implementation options, and optional run-time-configurable transform length. Cyclic-prefix insertion is disabled. |
+|`Gpio` | Xilinx *AXI General Purpose IO* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_gpio.html>) | Full configuration space |
+|`Microblaze` | Xilinx *AMD MicroBlaze™ Processor* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/microblaze.html>) | All configurations with local memory bus (No AXI DDR support) |
+|`Uartlite` | Xilinx *AXI UART Lite* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_uartlite.html>) | Full configuration space |
+|`XadcWiz` | Xilinx *XADC Wizard* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/xadc-wizard.html>) | Full configuration space |
+
+### IP Added as Needed
+
+These are not drawn from `available_ip`; the connection logic instances them as
+the design requires (interconnect/clocking/interrupt infrastructure, the AXI-Stream
+helpers, and the generic-wire glue built from `xlslice`/`xlconcat`).
+
+| Python Class | Description |
+|---------|-------------|
+|`AxiSmartconnect` | Xilinx *AXI SmartConnect* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/smartconnect.html>) |
+|`AxiInterconnect` | Xilinx *AXI Interconnect* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi-interconnect.html>) |
+|`AxisBroadcaster` | Xilinx *AXI4-Stream Broadcaster* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi4-stream-infrastructure.html>) — fans one stream source out to multiple sinks. |
+|`AxisCombiner` | Xilinx *AXI4-Stream Combiner* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi4-stream-infrastructure.html>) — merges multiple stream sources into one. |
+|`AxisDwidthConverter` | Xilinx *AXI4-Stream Data Width Converter* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi4-stream-infrastructure.html>) — resolves TDATA width mismatches between a stream source and sink. |
+|`ClkGen` | Xilinx *Clocking Wizard* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/clocking_wizard.html>) |
+|`Intc` | Xilinx *AXI Interrupt Controller* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/axi_intc.html>) |
+|`JtagAxi` | Xilinx *JTAG to AXI Master* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/jtag-to-axi-master.html>) — pin-free AXI master used by the no-master strategy. |
+|`SystemReset` | Xilinx *Processor System Reset* (<https://www.amd.com/en/products/adaptive-socs-and-fpgas/intellectual-property/proc_sys_reset.html>) — the single design-wide reset. |
+|`Reduce` | Generic-wire reducer built from `xlslice`/`xlconcat` primitives; narrows a wide signal down to a smaller sink. |
+|`SliceAndConcat` | Generic-wire glue built from `xlslice`/`xlconcat` primitives; drives a port from one or more narrower drivers. |
 
 ## Two kinds of IP
 


### PR DESCRIPTION
## Summary

The supported-IP list previously lived only in the README and had drifted out of date. The AXIS-branch IP and the generic-wire glue were never documented. This moves the canonical, complete list into `docs/ip.md` (derived from the `import_ip()` registry in `creator.py`) and points the README and docs index at it.

All **30** registered classes are now documented across two tables:

- **Randomized IP (19):** adds the previously-missing `Fft`, `Cordic`, `ConvolutionEncoder` (the one that prompted this), each with a configuration note drawn from its YAML.
- **IP Added as Needed (11):** adds `AxisBroadcaster`, `AxisCombiner`, `AxisDwidthConverter`, `JtagAxi`, and the `xlslice`/`xlconcat`/`proc_sys_reset` glue (`SystemReset`, `Reduce`, `SliceAndConcat`).

## Changes

- `docs/ip.md` — new `## Supported IP` section with both complete tables; note tying them to `import_ip()` so they stay in sync.
- `README.md` — replaced its incomplete two-table copy with a short overview that links to `docs/ip.md#supported-ip` (single source of truth).
- `docs/index.md` — fixed two stale references that pointed at the README for the IP table.

## Note
Base is `axi-stream` rather than `main` because the newly-documented IP only exist on this branch.

The AMD product-page URLs for the new rows follow the established link pattern but could not be verified (sandbox network is limited to `docs.amd.com`); worth a quick click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)