### PR TITLE
Emit synth utilization report from generated design.tcl

### DIFF
--- a/rand_soc/creator.py
+++ b/rand_soc/creator.py
@@ -226,6 +226,7 @@ class RandomDesign:
             "edif_path": "viv_synth.edf",
             "top": "bd_design_wrapper",
             "io_report_path": "report_io.txt",
+            "utilization_path": "synth_utilization.txt",
             "synthesize": self.synthesize,
         }
 

--- a/rand_soc/run.tcl.mustache
+++ b/rand_soc/run.tcl.mustache
@@ -39,6 +39,7 @@ write_checkpoint {{ checkpoint_path }} -force
 write_verilog {{ verilog_path }} -force
 write_edif {{ edif_path }} -force
 report_io -force -file {{ io_report_path }}
+report_utilization -file {{ utilization_path }}
 
 reset_project
 {{/synthesize}}


### PR DESCRIPTION
## Summary

The generated `design.tcl` runs synthesis and writes the checkpoint, verilog, edif, and IO report, but never a utilization report. Downstream consumers that expect a post-synth utilization report (e.g. bfasst's `VivadoSynth`, which declares `synth_utilization.txt` as a build output) therefore had no data and treated the synth step as perpetually out of date — breaking ninja idempotency in bfasst's rand_soc CI.

## Change

- Add `report_utilization -file synth_utilization.txt` in `run.tcl.mustache`, run while the synthesized design is still open (after `open_run synth_1`, before `reset_project`).
- Wire the output path through a new `utilization_path` entry in the creator's template config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)